### PR TITLE
Fixvarname

### DIFF
--- a/nohang
+++ b/nohang
@@ -826,7 +826,7 @@ def calculate_percent(arg_key):
         print('{} not in config\nExit'.format(arg_key))
         mem_min_percent = None
 
-    return mem_min_kb, mem_min_percent, mem_min_percent
+    return mem_min_kb, mem_min_mb, mem_min_percent
 
 
 # if 'mem_min_sigterm' in config_dict:

--- a/nohang
+++ b/nohang
@@ -1322,7 +1322,6 @@ if root and realtime_ionice:
 
 ##########################################################################
 
-
 if print_config:
 
     print('\n1. Memory levels to respond to as an OOM threat\n[displaying these options need fix]\n')


### PR DESCRIPTION
Repair variable names in calculate_percent() function. Now it returns (mem_min_kb, mem_min_mb, mem_min_perc) instead of (mem_min_kb, mem_min_perc, mem_min_perc)