### PR TITLE
[Logging] Use logging framework for the output

### DIFF
--- a/nohang
+++ b/nohang
@@ -11,6 +11,8 @@ from argparse import ArgumentParser
 from sys import stdout
 from signal import SIGKILL, SIGTERM
 
+import logging
+
 start_time = time()
 
 sig_dict = {SIGKILL: 'SIGKILL',
@@ -33,6 +35,16 @@ psi_path = '/proc/pressure/memory'
 
 psi_support = os.path.exists(psi_path)
 
+# Log configuration
+# TODO make it configurable from a config file?
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="\n[%(asctime)s] %(levelname)s\n%(message)s",
+)
+
+logger = logging.getLogger('nohang')
+logger.setLevel(logging.DEBUG)
 
 ##########################################################################
 
@@ -596,7 +608,7 @@ def find_victim_and_send_signal(signal):
         len_vm = len(str(vm_size))
 
         if detailed_rss:
-            victim_info = '\033[4mFound the victim with highest badness:\033[0m' \
+            victim_info = '\033[4mFound a victim with highest badness:\033[0m' \
                 '\n  Name:    \033[33m{}\033[0m' \
                 '\n  PID:     \033[33m{}\033[0m' \
                 '\n  UID:     \033[33m{}\033[0m' \
@@ -616,7 +628,7 @@ def find_victim_and_send_signal(signal):
                     anon_rss, file_rss, shmem_rss,
                     str(vm_swap).rjust(len_vm, ' '), cmdline)
         else:
-            victim_info = '\033[4mFound the victim with highest badness:\033[0m' \
+            victim_info = '\033[4mFound a victim with highest badness:\033[0m' \
                 '\n  Name:    \033[33m{}\033[0m' \
                 '\n  PID:     \033[33m{}\033[0m' \
                 '\n  UID:     \033[33m{}\033[0m' \
@@ -655,8 +667,9 @@ def find_victim_and_send_signal(signal):
                 new_value = stat_dict[key] + 1
                 stat_dict.update({key: new_value})
 
-            print(mem_info)
-            print(etc_info)
+            logger.info(mem_info)
+            logger.info(etc_info)
+
             if gui_notifications:
                 send_notify_etc(pid, name, command)
 
@@ -690,15 +703,20 @@ def find_victim_and_send_signal(signal):
                     round(response_time * 1000))
 
             preventing_oom_message = '{}' \
-                '\n\033[4mImplement corrective action:\033[0m\n  ' \
+                '\n\033[4mImplement a corrective action:\033[0m\n  ' \
                 'Sending \033[4m{}\033[0m to the victim; {}'.format(
                     victim_info, sig_dict[signal], send_result)
-            print(mem_info)
-            print(preventing_oom_message)
-            print('\n\033[4mDuration of work: {}; number of corrective actions:\033[0m'.format(
-                format_time(time() - start_time)))
+
+            logger.info(mem_info)
+            logger.info(preventing_oom_message)
+
+            stats_msg = '\033[4mUptime: {}; corrective actions:\033[0m'.format(
+                format_time(time() - start_time))
+
             for key in stat_dict:
-                print('  - {}: {}'.format(key, stat_dict[key]))
+                stats_msg += '\n  - {}: {}'.format(key, stat_dict[key])
+
+            logger.info(stats_msg)
 
     else:
 
@@ -1482,7 +1500,7 @@ warn_time_delta = 1000
 warn_timer = 0
 
 x = time() - start_time
-print('The duration of startup:',
+print('Startup time:',
       round(x * 1000, 1), 'ms')
 
 print('Monitoring started!')
@@ -1684,7 +1702,7 @@ while True:
             swap_free <= swap_min_sigkill_kb:
         time0 = time()
 
-        mem_info = '\n\033[4mMemory status that requires corrective actions:' \
+        mem_info = '\033[4mMemory status that requires corrective actions:' \
             '\033[0m\n  MemAvailable [{} MiB, {} %] <= mem_min_sig' \
             'kill [{} MiB, {} %]\n  SwapFree [{} MiB, {} %] <= swa' \
             'p_min_sigkill [{} MiB, {} %]'.format(
@@ -1705,7 +1723,7 @@ while True:
     elif mem_used_zram >= zram_max_sigkill_kb:
         time0 = time()
 
-        mem_info = '\n\033[4mMemory status that requires corrective actions:' \
+        mem_info = '\033[4mMemory status that requires corrective actions:' \
             '\033[0m\n  MemUsedZram [{} MiB, {} %] >= zram_max_sig' \
             'kill [{} MiB, {} %]'.format(
                 kib_to_mib(mem_used_zram),
@@ -1723,7 +1741,7 @@ while True:
 
         time0 = time()
 
-        mem_info = '\n\033[4mMemory status that requires corrective actions:' \
+        mem_info = '\033[4mMemory status that requires corrective actions:' \
             '\033[0m\n  MemAvailable [{} MiB, {} %] <= mem_min_sig' \
             'term [{} MiB, {} %]\n  SwapFree [{} MiB, {} %] <= swa' \
             'p_min_sigterm [{} MiB, {} %]'.format(
@@ -1746,7 +1764,7 @@ while True:
     elif mem_used_zram >= zram_max_sigterm_kb:
         time0 = time()
 
-        mem_info = '\n\033[4mMemory status that requires corrective actions:' \
+        mem_info = '\033[4mMemory status that requires corrective actions:' \
             '\033[0m\n  MemUsedZram [{} MiB, {} %] >= ' \
             'zram_max_sigterm [{} M, {} %]'.format(
                 kib_to_mib(mem_used_zram),


### PR DESCRIPTION
Hi, I'd like to propose a change from raw `print` to using python logging framework.

The main reason is every log message automatically gets a timestamp which is useful to understand when each action happened and how the state changed when a user was away.

Other reasons include a customizable message format, an ability to write into files, syslog, etc. Also it should simplify output settings by having some defined levels, eg `info`, `warning`, `debug` and so on.

I'd like to gradually migrate and remove all the prints. What do you think?

Here's an example of how new log looks like:
```
The path to the config: /home/maxim/apps/nohang/nohang.conf
Startup time: 2.7 ms
Monitoring started!

[2019-01-08 13:21:11,252] INFO
Memory status that requires corrective actions:
  MemAvailable [1576 MiB, 9.9 %] <= mem_min_sigterm [1593 MiB, 10.0 %]
  SwapFree [0 MiB, 0.0 %] <= swap_min_sigterm [0 MiB, - %]

[2019-01-08 13:21:11,252] INFO
Found the victim with highest badness:
  Name:    chromium-browse
  PID:     30379
  UID:     1000
  Badness: 325, oom_score: 325, oom_score_adj: 300
  VmSize:  2194 MiB
  VmRSS:    411 MiB (Anon: 224 MiB, File: 68 MiB, Shmem: 118 MiB)
  VmSwap:     0 MiB
  CmdLine: /usr/lib/chromium-browser/chromium-browser --type=renderer --field-trial-handle=8469468451111274708,17758958089990327280,131072 --service-pipe-token=10426831563939142227 --lang=en-US --enable-offline-auto-reload --enable-offline-auto-reload-visible-only --ppapi-flash-path=/usr/lib/adobe-flashplugin/libpepflashplayer.so --ppapi-flash-version=32.0.0.101 --num-raster-threads=4 --enable-main-frame-before-activation --service-request-channel-token=10426831563939142227 --renderer-client-id=12 --no-v8-untrusted-code-mitigations --shared-files=v8_context_snapshot_data:100,v8_natives_data:101
Implement corrective action:
  Sending SIGTERM to the victim; OK; response time: 12 ms

[2019-01-08 13:21:11,252] INFO
Uptime: 9 sec; number of corrective actions:
  - Send SIGTERM to chromium-browse: 1

[2019-01-08 13:21:17,683] INFO
Memory status that requires corrective actions:
  MemAvailable [1580 MiB, 9.9 %] <= mem_min_sigterm [1593 MiB, 10.0 %]
  SwapFree [0 MiB, 0.0 %] <= swap_min_sigterm [0 MiB, - %]

[2019-01-08 13:21:17,684] INFO
Found the victim with highest badness:
  Name:    chromium-browse
  PID:     20448
  UID:     1000
  Badness: 326, oom_score: 326, oom_score_adj: 300
  VmSize:  2499 MiB
  VmRSS:    420 MiB (Anon: 344 MiB, File: 69 MiB, Shmem: 7 MiB)
  VmSwap:     0 MiB
  CmdLine: /usr/lib/chromium-browser/chromium-browser --type=renderer --field-trial-handle=8469468451111274708,17758958089990327280,131072 --service-pipe-token=1219661694341896680 --lang=en-US --enable-offline-auto-reload --enable-offline-auto-reload-visible-only --ppapi-flash-path=/usr/lib/adobe-flashplugin/libpepflashplayer.so --ppapi-flash-version=32.0.0.101 --num-raster-threads=4 --enable-main-frame-before-activation --service-request-channel-token=1219661694341896680 --renderer-client-id=13 --no-v8-untrusted-code-mitigations --shared-files=v8_context_snapshot_data:100,v8_natives_data:101
Implement corrective action:
  Sending SIGTERM to the victim; OK; response time: 16 ms

[2019-01-08 13:21:17,684] INFO
Uptime: 15 sec; number of corrective actions:
  - Send SIGTERM to chromium-browse: 2
```