### PR TITLE
Add copyright header to .spec file

### DIFF
--- a/rpm/nohang-dev.spec
+++ b/rpm/nohang-dev.spec
@@ -1,5 +1,28 @@
 ### Automated build version of dev branch
 
+#
+# Copyright © 2019 Artem Polishchuk <ego.cordatus@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
 %define build_timestamp %{lua: print(os.date("%Y%m%d.%H"))}
 %global appname nohang
 


### PR DESCRIPTION
At least openSUSE requires a copyright header and they tend to add their own copyright if there isn't one. This adds a header to prevent any illegal "accidental" copyright reassignment from occurring.