### PR TITLE
Update service file templates to use envsubst rather than sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ install:
 
 ifeq ($(shell which systemctl), /usr/sbin/systemctl)
 	-install -d $(DESTDIR)$(SYSTEMDUNIT# DIR)
-	-sed "s|:TARGET_BIN:|$(BINDIR)|g;s|:TARGET_CONF:|$(CONFDIR)|g" nohang/nohang.service.in > nohang.service
-	-sed "s|:TARGET_BIN:|$(BINDIR)|g;s|:TARGET_CONF:|$(CONFDIR)|g" nohang/nohang-desktop.service.in > nohang-desktop.service
+	env BINDIR=$(BINDIR) CONFDIR=$(CONFDIR) envsubst < nohang/nohang.service.in > nohang.service
+	env BINDIR=$(BINDIR) CONFDIR=$(CONFDIR) envsubst < nohang/nohang-desktop.service.in > nohang-desktop.service
 	-install -m0644 nohang.service $(DESTDIR)$(SYSTEMDUNITDIR)/nohang.service
 	-install -m0644 nohang-desktop.service $(DESTDIR)$(SYSTEMDUNITDIR)/nohang-desktop.service
 	-rm -fv nohang.service
@@ -50,8 +50,8 @@ endif
 
 ifeq ($(shell which openrc), /sbin/openrc)
 	install -d $(DESTDIR)$(CONFDIR)/init.d
-	-sed "s|:TARGET_BIN:|$(BINDIR)|g;s|:TARGET_CONF:|$(CONFDIR)|g" nohang/openrc/nohang.in > nohang/openrc/nohang
-	-sed "s|:TARGET_BIN:|$(BINDIR)|g;s|:TARGET_CONF:|$(CONFDIR)|g" nohang/openrc/nohang-desktop.in > nohang/openrc/nohang-desktop
+	env BINDIR=$(BINDIR) CONFDIR=$(CONFDIR) envsubst < nohang/openrc/nohang.in > nohang/openrc/nohang
+	env BINDIR=$(BINDIR) CONFDIR=$(CONFDIR) envsubst < nohang/openrc/nohang-desktop.in > nohang/openrc/nohang-desktop
 	install -m0775 nohang/openrc/nohang $(DESTDIR)$(CONFDIR)/init.d/nohang
 	install -m0775 nohang/openrc/nohang-desktop $(DESTDIR)$(CONFDIR)/init.d/nohang-desktop
 endif

--- a/nohang/nohang-desktop.service.in
+++ b/nohang/nohang-desktop.service.in
@@ -5,7 +5,7 @@ Conflicts=nohang.service
 After=system.slice
 
 [Service]
-ExecStart=:TARGET_BIN:/nohang --config :TARGET_CONF:/nohang/nohang-desktop.conf
+ExecStart=${BINDIR}/nohang --config ${CONFDIR}/nohang/nohang-desktop.conf
 SyslogIdentifier=nohang-desktop
 
 KillMode=mixed

--- a/nohang/nohang.service.in
+++ b/nohang/nohang.service.in
@@ -5,7 +5,7 @@ Conflicts=nohang-desktop.service
 After=system.slice
 
 [Service]
-ExecStart=:TARGET_BIN:/nohang --config :TARGET_CONF:/nohang/nohang.conf
+ExecStart=${BINDIR}/nohang --config ${CONFDIR}/nohang/nohang.conf
 SyslogIdentifier=nohang
 
 KillMode=mixed

--- a/nohang/openrc/nohang-desktop.in
+++ b/nohang/openrc/nohang-desktop.in
@@ -4,7 +4,7 @@
 
 name="nohang-desktop daemon"
 description="Sophisticated low memory handler"
-command=:TARGET_BIN:/nohang
-command_args="--config :TARGET_CONF:/nohang/nohang-desktop.conf"
+command=${BINDIR}/nohang
+command_args="--config ${CONFDIR}/nohang/nohang-desktop.conf"
 pidfile="/var/run/nohang-desktop"
 start_stop_daemon_args="--background --make-pidfile"

--- a/nohang/openrc/nohang-desktop.in
+++ b/nohang/openrc/nohang-desktop.in
@@ -1,0 +1,10 @@
+#!/sbin/openrc-run
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+name="nohang-desktop daemon"
+description="Sophisticated low memory handler"
+command=:TARGET_BIN:/nohang
+command_args="--config :TARGET_CONF:/nohang/nohang-desktop.conf"
+pidfile="/var/run/nohang-desktop"
+start_stop_daemon_args="--background --make-pidfile"

--- a/nohang/openrc/nohang.in
+++ b/nohang/openrc/nohang.in
@@ -4,7 +4,7 @@
 
 name="nohang daemon"
 description="Sophisticated low memory handler"
-command=:TARGET_BIN:/nohang
-command_args="--config :TARGET_CONF:/nohang/nohang.conf"
+command=${BINDIR}/nohang
+command_args="--config ${CONFDIR}/nohang/nohang.conf"
 pidfile="/var/run/nohang"
 start_stop_daemon_args="--background --make-pidfile"

--- a/nohang/openrc/nohang.in
+++ b/nohang/openrc/nohang.in
@@ -1,0 +1,10 @@
+#!/sbin/openrc-run
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+name="nohang daemon"
+description="Sophisticated low memory handler"
+command=:TARGET_BIN:/nohang
+command_args="--config :TARGET_CONF:/nohang/nohang.conf"
+pidfile="/var/run/nohang"
+start_stop_daemon_args="--background --make-pidfile"


### PR DESCRIPTION
Just a minor change, building off my other pull request. Rather than deploying templated service files via `sed`, we can use `envsubst` which is a rather clean way to swap out environment variables for their content.