### PR TITLE
Update service file templates to use envsubst rather than sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ install:
 	gzip -c tools/psi2log.1 > $(DESTDIR)$(MANDIR)/psi2log.1.gz
 
 	-install -d $(DESTDIR)$(SYSTEMDUNITDIR)
-	-sed "s|:TARGET_BIN:|$(BINDIR)|g;s|:TARGET_CONF:|$(CONFDIR)|g" nohang/nohang.service.in > nohang.service
-	-sed "s|:TARGET_BIN:|$(BINDIR)|g;s|:TARGET_CONF:|$(CONFDIR)|g" nohang/nohang-desktop.service.in > nohang-desktop.service
+	env BINDIR=$(BINDIR) CONFDIR=$(CONFDIR) envsubst < nohang/nohang.service.in > nohang.service
+	env BINDIR=$(BINDIR) CONFDIR=$(CONFDIR) envsubst < nohang/nohang-desktop.service.in > nohang-desktop.service
 	-install -m0644 nohang.service $(DESTDIR)$(SYSTEMDUNITDIR)/nohang.service
 	-install -m0644 nohang-desktop.service $(DESTDIR)$(SYSTEMDUNITDIR)/nohang-desktop.service
 	-rm -fv nohang.service

--- a/nohang/nohang-desktop.service.in
+++ b/nohang/nohang-desktop.service.in
@@ -5,7 +5,7 @@ Conflicts=nohang.service
 After=system.slice
 
 [Service]
-ExecStart=:TARGET_BIN:/nohang --config :TARGET_CONF:/nohang/nohang-desktop.conf
+ExecStart=${BINDIR}/nohang --config ${CONFDIR}/nohang/nohang-desktop.conf
 SyslogIdentifier=nohang-desktop
 
 KillMode=mixed

--- a/nohang/nohang.service.in
+++ b/nohang/nohang.service.in
@@ -5,7 +5,7 @@ Conflicts=nohang-desktop.service
 After=system.slice
 
 [Service]
-ExecStart=:TARGET_BIN:/nohang --config :TARGET_CONF:/nohang/nohang.conf
+ExecStart=${BINDIR}/nohang --config ${CONFDIR}/nohang/nohang.conf
 SyslogIdentifier=nohang
 
 KillMode=mixed


### PR DESCRIPTION
As briefly discussed here  #77, just a minor change. Rather than deploying templated service files via sed, we can use envsubst which is a rather clean way to swap out environment variables for their content.