### PR TITLE
[docs] Arch: Start nohang after install

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,13 @@ To enable PSI on RHEL 8 pass `psi=1` to kernel boot cmdline.
 
 Use your favorite [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
 ```bash
-$ yay -S nohang-git
+$ yay -S nohang-gitdesktop
 $ sudo systemctl enable --now nohang-desktop.service
+$ sudo systemctl start nohang-desktop.service
 ```
 
-#### To install on Ubuntu 20.04/20.10
+#### To install on Ubuntu 20.04/20.10$ sudo systemctl start nohang-desktop.service
+
 
 To install from [PPA](https://launchpad.net/~oibaf/+archive/ubuntu/test/):
 ```bash

--- a/README.md
+++ b/README.md
@@ -142,8 +142,7 @@ $ sudo systemctl enable --now nohang-desktop.service
 $ sudo systemctl start nohang-desktop.service
 ```
 
-#### To install on Ubuntu 20.04/20.10$ sudo systemctl start nohang-desktop.service
-
+#### To install on Ubuntu 20.04/20.10
 
 To install from [PPA](https://launchpad.net/~oibaf/+archive/ubuntu/test/):
 ```bash

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To enable PSI on RHEL 8 pass `psi=1` to kernel boot cmdline.
 
 Use your favorite [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
 ```bash
-$ yay -S nohang-gitdesktop
+$ yay -S nohang-git
 $ sudo systemctl enable --now nohang-desktop.service
 $ sudo systemctl start nohang-desktop.service
 ```


### PR DESCRIPTION
I just installed `nohang` on Arch Linux but the service wasn't started and had to run:
```
$ sudo systemctl start nohang-desktop.service
```